### PR TITLE
fix the conflicting variable definition for MPICC and MPICXX

### DIFF
--- a/libs/fftw.mak
+++ b/libs/fftw.mak
@@ -8,7 +8,7 @@ define fftw_template_opt
 	target_ver="$(FFTW_VER)" \
 	target_dep="$(fftw_dep)" \
 	target_url="http://www.fftw.org/fftw-${FFTW_VER}.tar.gz" \
-	target_confcmd="CC=$(MPICC) CXX=$(MPICXX) FC=$(MPIFORT) F77=$(MPIFORT) ./configure --prefix=${PREFIX}" \
+	target_confcmd="CC=$(DBS_MPICC) CXX=$(MPICXX) FC=$(MPIFORT) F77=$(MPIFORT) ./configure --prefix=${PREFIX}" \
 	target_confopt="--disable-fortran --enable-openmp --enable-sse2 --enable-avx --enable-avx2"
 endef
 

--- a/libs/flups.mak
+++ b/libs/flups.mak
@@ -39,7 +39,7 @@ ifdef FLUPS_VER
 	cp $(TAR_DIR)/$(FLUPS_DIR).tar.gz $(COMP_DIR)  && \
 	tar -xvf $(FLUPS_DIR).tar.gz  && \
 	cd $(FLUPS_DIR) && \
-	CC=${MPICC} CXX=${MPICXX} \
+	CC=${DBS_MPICC} CXX=${MPICXX} \
 		CXXFLAGS="$(FLUPS_CXXFLAGS)" CCFLAGS="$(FLUPS_CCFLAGS)" LDFLAGS="$(FLUPS_LDFLAGS)" \
 		HDF5_DIR=${PREFIX} FFTW_DIR=${PREFIX} \
 		$(MAKE) install -j 8 && \

--- a/libs/hdf5.mak
+++ b/libs/hdf5.mak
@@ -12,7 +12,7 @@ define hdf5_template_opt
 	target_ver="$(HDF5_VER)" \
 	target_dep="$(hdf5_dep)" \
 	target_url="http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-1.12/hdf5-$(HDF5_VER)/src/hdf5-$(HDF5_VER).tar.bz2" \
-	target_confcmd="CC=$(MPICC) CXX=$(MPICXX) FC=$(MPIFORT) F77=$(MPIFORT) ./configure --prefix=${PREFIX}" \
+	target_confcmd="CC=$(DBS_MPICC) CXX=$(MPICXX) FC=$(MPIFORT) F77=$(MPIFORT) ./configure --prefix=${PREFIX}" \
 	target_confopt="--enable-parallel --enable-optimization=high --enable-build-mode=production --with-default-api-version=v110 $(hdf5_zlib)"
 endef
 

--- a/libs/ofi.mak
+++ b/libs/ofi.mak
@@ -8,6 +8,7 @@ define ofi_template_opt
 	target_ver="$(OFI_VER)" \
 	target_dep="$(ofi_dep)" \
 	target_url="https://github.com/ofiwg/libfabric/archive/refs/tags/v$(OFI_VER).tar.gz" \
+	target_precmd="./autogen.sh" \
 	target_confcmd="CC=$(CC) CXX=$(CXX) FC=$(FC) F77=$(FC) ./configure --prefix=${PREFIX}"
 endef
 

--- a/libs/ompi.mak
+++ b/libs/ompi.mak
@@ -40,11 +40,11 @@ endef
 
 #===============================================================================
 ifdef OMPI_VER
-MPICC = $(PREFIX)/bin/mpicc
+DBS_MPICC = $(PREFIX)/bin/mpicc
 MPICXX = $(PREFIX)/bin/mpic++
 MPIFORT = $(PREFIX)/bin/mpif90
 else
-MPICC = mpicc
+DBS_MPICC = mpicc
 MPICXX = mpic++
 MPIFORT = mpif90
 endif

--- a/libs/p4est.mak
+++ b/libs/p4est.mak
@@ -8,7 +8,7 @@ define p4est_template_opt
 	target_ver="$(P4EST_VER)" \
 	target_dep="$(p4est_dep)" \
 	target_url="https://p4est.github.io/release/p4est-$(P4EST_VER).tar.gz" \
-	target_confcmd="CC=$(MPICC) CXX=$(MPICXX) FC=$(MPIFORT) F77=$(MPIFORT) ./configure --prefix=${PREFIX}" \
+	target_confcmd="CC=$(DBS_MPICC) CXX=$(MPICXX) FC=$(MPIFORT) F77=$(MPIFORT) ./configure --prefix=${PREFIX}" \
 	target_confopt="--enable-mpi --enable-openmp --with-blas=-lopenblas"
 endef
 

--- a/libs/ucx.mak
+++ b/libs/ucx.mak
@@ -8,8 +8,7 @@ define ucx_template_opt
 	target_ver="$(UCX_VER)" \
 	target_dep="$(ucx_dep)" \
 	target_url="https://github.com/openucx/ucx/releases/download/v$(UCX_VER)/ucx-$(UCX_VER).tar.gz" \
-	target_confcmd="CC=$(CC) CXX=$(CXX) FC=$(FC) F77=$(FC) ./configure --prefix=${PREFIX}" \
-	target_confopt="--enable-compiler-opt=3"
+	target_confcmd="CC=$(CC) CXX=$(CXX) FC=$(FC) F77=$(FC) ./contrib/configure-release --prefix=${PREFIX}"
 endef
 
 #===============================================================================


### PR DESCRIPTION
defines new `DBS_MPICC` and `DBS_MPICXX` instead