### PR TITLE
fixes the touch issue causing a recompilation of the lib some are not defined

### DIFF
--- a/template.mak
+++ b/template.mak
@@ -42,8 +42,8 @@ $(COMP_DIR)/tmp_$(target):
 doit: $(PREFIX)/$(target).complete
 
 .PHONY: tit
-tit:  | $(PREFIX)
-	touch $(PREFIX)/$(target).complete
+tit: | $(PREFIX)
+	touch -a $(PREFIX)/$(target).complete
 
 .PHONY: tar
 tar: $(TAR_DIR)/$(target)-$(target_ver).tar.gz


### PR DESCRIPTION
changes the `touch` to only change the access time-stamp if the file already exist.
It allows to not redo a lib if the file is empty and has been touched