### PR TITLE
`parmetis` dependencies +  Perlmutter Config

### DIFF
--- a/config/perlmutter/default.arch
+++ b/config/perlmutter/default.arch
@@ -1,0 +1,45 @@
+#===============================================================================
+# GENERAL PARAMETERS
+CC = gcc
+CXX = g++
+FC = gfortran
+DBS_MPICC = cc
+DBS_MPICXX = CC
+DBS_MPIFORT = ftn
+
+BUILD_DIR = $(PSCRATCH)
+TAR_DIR = $(HOME)/tar_storage
+PREFIX = $(HOME)/lib-dbs-perlmutter
+
+define MODULE_LIST
+module unload gpu 
+module load cpu
+module swap craype-$${CRAY_CPU_TARGET} craype-x86-milan
+module swap PrgEnv-$${PE_ENV,,} PrgEnv-gnu
+module load cray-mpich 
+module load cray-hdf5-parallel
+module load cray-fftw
+module unload cray-libsci
+endef
+
+#===============================================================================
+# LIBRARIES
+# mpi is system mpich
+# other system libs (versions updated Oct. 18th 2023)
+# HDF5_VER = 1.12.2
+# FFTW_VER = 3.3.10
+
+# provided by e4s-22.11 (versions updated Oct. 18th 2023)
+# PETSC_VER = 3.18.1
+# HYPRE_VER = 2.26.0
+
+# OpenBLAS has a Cray FORTRAN compiler bug in 0.3.21, use a later version
+OBLAS_VER = 0.3.24
+
+# in-house libs (compiled)
+P4EST_VER = 2.8
+FLUPS_VER = develop
+FLUPS_FFTW_DIR = ${FFTW_ROOT}
+FLUPS_HDF5_DIR = ${HDF5_ROOT}
+H3LPR_VER = main
+

--- a/config/perlmutter/default.sh
+++ b/config/perlmutter/default.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+#SBATCH --qos=debug
+#SBATCH --time=0:20:00
+#SBATCH --nodes=1
+#SBATCH --ntasks=128
+#SBATCH --cpus-per-task=2
+#SBATCH --constraint=cpu
+#SBATCH --ntasks=1
+
+#-------------------------------------------------------------------------------
+module unload gpu 
+module load cpu
+module swap craype-${CRAY_CPU_TARGET} craype-x86-milan
+module swap PrgEnv-${PE_ENV,,} PrgEnv-gnu
+module load cray-mpich 
+module load cray-hdf5-parallel
+module load cray-fftw
+module unload cray-libsci
+#-------------------------------------------------------------------------------
+module list
+#-------------------------------------------------------------------------------
+CLUSTER=perlmutter/default make info
+CLUSTER=perlmutter/default make install
+#-------------------------------------------------------------------------------

--- a/libs/parmetis.mak
+++ b/libs/parmetis.mak
@@ -9,7 +9,7 @@ PARMETIS_DIR = parmetis-$(PARMETIS_VER)
 
 #===============================================================================
 .PHONY: parmetis
-parmetis: $(PREFIX)/parmetis.complete
+parmetis: $(parmetis_dep) $(PREFIX)/parmetis.complete
 
 #-------------------------------------------------------------------------------
 parmetis_tar: $(TAR_DIR)/$(PARMETIS_DIR).tar.gz


### PR DESCRIPTION
A few small things:
 - fixes a bug with the `parmetis` target dependencies that was preventing builds without `parmetis`
 - adds the `perlmutter/default` configuration, which I've used to run on Perlmutter